### PR TITLE
GCP Compute module service account linkage

### DIFF
--- a/gcp/vm/data.tf
+++ b/gcp/vm/data.tf
@@ -14,11 +14,11 @@ data "google_compute_subnetwork" "default" {
     self_link = "${element(var.subnetworks, 0)}"
 }
 
-data "google_service_account" "custom-sc" {
+data "google_service_account" "custom-service-account" {
     count = "${var.service_account_id != "" ? 1 : 0}"
     account_id = "${var.service_account_id}"
 }
 
-data "google_compute_default_service_account" "defaut-sc" {
+data "google_compute_default_service_account" "defaut-service-account" {
     count = "${var.service_account_id == "" ? 1 : 0}"
 }

--- a/gcp/vm/data.tf
+++ b/gcp/vm/data.tf
@@ -13,3 +13,12 @@ data "google_compute_image" "default" {
 data "google_compute_subnetwork" "default" {
     self_link = "${element(var.subnetworks, 0)}"
 }
+
+data "google_service_account" "custom-sc" {
+    count = "${var.service_account_id != "" ? 1 : 0}"
+    account_id = "${var.service_account_id}"
+}
+
+data "google_compute_default_service_account" "defaut-sc" {
+    count = "${var.service_account_id == "" ? 1 : 0}"
+}

--- a/gcp/vm/main.tf
+++ b/gcp/vm/main.tf
@@ -21,6 +21,11 @@ resource "google_compute_instance" "no_external" {
 
         //No external IP
     }
+
+    service_account {
+        email = "${element(concat(data.google_service_account.custom-sc.*.email, data.google_compute_default_service_account.defaut-sc.*.email), 0)}"
+        scopes = ["cloud-platform"]
+    }
 }
 
 resource "google_compute_instance" "external_ip" {
@@ -43,6 +48,11 @@ resource "google_compute_instance" "external_ip" {
         access_config {
             nat_ip = "${element(google_compute_address.default.*.address, count.index)}"
         }
+    }
+
+    service_account {
+        email = "${element(concat(data.google_service_account.custom-sc.*.email, data.google_compute_default_service_account.defaut-sc.*.email), 0)}"
+        scopes = ["cloud-platform"]
     }
 }
 

--- a/gcp/vm/main.tf
+++ b/gcp/vm/main.tf
@@ -23,7 +23,7 @@ resource "google_compute_instance" "no_external" {
     }
 
     service_account {
-        email = "${element(concat(data.google_service_account.custom-sc.*.email, data.google_compute_default_service_account.defaut-sc.*.email), 0)}"
+        email = "${element(concat(data.google_service_account.custom-service-account.*.email, data.google_compute_default_service_account.defaut-service-account.*.email), 0)}"
         scopes = ["cloud-platform"]
     }
 }
@@ -51,7 +51,7 @@ resource "google_compute_instance" "external_ip" {
     }
 
     service_account {
-        email = "${element(concat(data.google_service_account.custom-sc.*.email, data.google_compute_default_service_account.defaut-sc.*.email), 0)}"
+        email = "${element(concat(data.google_service_account.custom-service-account.*.email, data.google_compute_default_service_account.defaut-service-account.*.email), 0)}"
         scopes = ["cloud-platform"]
     }
 }

--- a/gcp/vm/vars.tf
+++ b/gcp/vm/vars.tf
@@ -66,3 +66,9 @@ variable "static_public_ip" {
   description = "Whether or not to create (and attach) an external static IP"
   default     = false
 }
+
+variable "service_account_id" {
+  description = "GCE Service Account ID to apply on all instances. Will fallback to default service account if empty"
+  type = "string"
+  default = ""
+}


### PR DESCRIPTION
GCP Compute module service account linkage
Description
This module now supports instance linkage with specific GCE service accounts or GCP default service account (project scope) if a service account id is not provided.

Type of change
  Bug fix (non-breaking change which fixes an issue)
  New feature (non-breaking change which adds functionality)
  Breaking change (fix or feature that would cause existing functionality to not work as expected)
  This change requires a documentation update
How Has This Been Tested?
Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

  terraform plan
  terraform apply
Test Configuration:

Terraform version: 0.11.13
Checklist:
  My code follows the style guidelines of this project
  I have performed a self-review of my own code
  I have commented my code, particularly in hard-to-understand areas
  I have made corresponding changes to the documentation
  My changes generate no new warnings
  I have added tests that prove my fix is effective or that my feature works
  New and existing unit tests pass locally with my changes
  Any dependent changes have been merged and published in downstream modules